### PR TITLE
index transaction.external_id

### DIFF
--- a/payment_gateway/models/gateway_transaction.py
+++ b/payment_gateway/models/gateway_transaction.py
@@ -40,7 +40,7 @@ class GatewayTransaction(models.Model):
     payment_mode_id = fields.Many2one(
         'account.payment.mode',
         'Gateway')
-    external_id = fields.Char()
+    external_id = fields.Char(index=True)
     capture_payment = fields.Selection(
         selection="_selection_capture_payment",
         required=True)


### PR DESCRIPTION
the transaction records are always searched using their external_id field key. But if you have thousands or more of transactions, you will have thousands of external_id, so it's better to have an index on it. We probably don't have the case yet, but it will make no additional cost for small websites while it will make a difference on very large websites (just like when you have millions of products or partners in Odoo).