### PR TITLE
[FIX] fix transaction when origin has no name + improve Adyen logging

### DIFF
--- a/payment_gateway/models/gateway_transaction.py
+++ b/payment_gateway/models/gateway_transaction.py
@@ -131,7 +131,7 @@ class GatewayTransaction(models.Model):
     def _prepare_transaction(self, origin, **kwargs):
         mode = origin.payment_mode_id
         return {
-            'name': origin.name,
+            'name': origin.name or str(origin),
             'payment_mode_id': mode.id,
             'capture_payment': mode.capture_payment,
             'redirect_cancel_url': kwargs.get('redirect_cancel_url'),

--- a/payment_gateway_adyen/services/payment_service.py
+++ b/payment_gateway_adyen/services/payment_service.py
@@ -117,6 +117,7 @@ class PaymentService(Component):
                     code = 'undef'
             self._raise_error_message(code)
         except Exception as e:
+            _logger.info("Adyen error: %s" % e)
             self._raise_error_message('undef')
 
     def process_return(self, browser_info=None, md=None, pares=None,


### PR DESCRIPTION
In some particular cases, the origin.name could not be filled at the time of the payment.
When a technical error is returned, the catch hide it. The PR add it in Odoo logs