### PR TITLE
[10.0] payment_gateway: allow to specify the connection account per payment mode

### DIFF
--- a/payment_gateway/models/account_payment_mode.py
+++ b/payment_gateway/models/account_payment_mode.py
@@ -11,6 +11,10 @@ class AccountPaymentMode(models.Model):
     _inherit = 'account.payment.mode'
 
     provider = fields.Selection(selection='_selection_provider')
+    provider_account = fields.Many2one(
+        comodel_name='keychain.account',
+        domain=[('namespace', '!=', False)]
+    )
     capture_payment = fields.Selection(selection='_selection_capture_payment')
 
     def _selection_capture_payment(self):

--- a/payment_gateway/views/account_payment_mode_view.xml
+++ b/payment_gateway/views/account_payment_mode_view.xml
@@ -10,6 +10,7 @@
                     name="capture_payment"
                     attrs="{'invisible': [('provider', '=', False)],
                             'required': [('provider', '!=', False)]}"/>
+                <field name="provider_account"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
This feature is useful when you want to use different provider account on the same odoo instance