### PR TITLE
[10.0][ADD][FIX] Store the current_transaction_id into mixin model

### DIFF
--- a/payment_gateway/models/account_invoice.py
+++ b/payment_gateway/models/account_invoice.py
@@ -22,4 +22,8 @@ class AccountInvoice(models.Model):
         return self.residual
 
     def _get_transaction_name_based_on_origin(self):
-        return self.number
+        transaction_name = self.number
+        if not transaction_name:
+            transaction_name = super(
+                AccountInvoice, self)._get_transaction_name_based_on_origin()
+        return transaction_name

--- a/payment_gateway/models/gateway_transaction.py
+++ b/payment_gateway/models/gateway_transaction.py
@@ -55,8 +55,16 @@ class GatewayTransaction(models.Model):
             ('sale.order', 'Sale Order'),
             ('account.invoice', 'Account Invoice'),
             ])
-    res_model = fields.Char(compute='_compute_origin', store=True)
-    res_id = fields.Integer(compute='_compute_origin', store=True)
+    res_model = fields.Char(
+        compute='_compute_origin',
+        store=True,
+        index=True,
+    )
+    res_id = fields.Integer(
+        compute='_compute_origin',
+        store=True,
+        index=True,
+    )
     partner_id = fields.Many2one(
         'res.partner',
         'Partner')
@@ -153,6 +161,8 @@ class GatewayTransaction(models.Model):
         """
         vals = self._prepare_transaction(origin, **kwargs)
         transaction = self.create(vals)
+        if transaction.origin_id:
+            transaction.origin_id._compute_current_transaction()
         with transaction._get_provider(provider_name) as provider:
             provider.generate(**kwargs)
         return transaction

--- a/payment_gateway/models/transaction_mixin.py
+++ b/payment_gateway/models/transaction_mixin.py
@@ -25,7 +25,9 @@ class TransactionMixin(models.AbstractModel):
     current_transaction_id = fields.Many2one(
         'gateway.transaction',
         'Current Transaction',
-        compute='_compute_current_transaction')
+        compute='_compute_current_transaction',
+        store=True,
+    )
 
     @api.multi
     def _get_transaction_to_capture_amount(self):
@@ -47,9 +49,9 @@ class TransactionMixin(models.AbstractModel):
     @api.depends('transaction_ids')
     def _compute_current_transaction(self):
         for record in self:
-            # Load the more recent transaction (to order on the transaction
-            # models set the first as the most recent)
-            record.current_transaction_id = first(record.transaction_ids)
+            # Load the more recent transaction
+            record.current_transaction_id = first(
+                record.transaction_ids.sorted('id', reverse=True))
 
     def _get_transaction_name_based_on_origin(self):
-        return self.name
+        return self.name or ('%s with id %s' % (self._name, self.id))

--- a/payment_gateway/tests/common.py
+++ b/payment_gateway/tests/common.py
@@ -59,6 +59,7 @@ class HttpComponentCase(HttpCase, ComponentMixin):
         super(HttpComponentCase, cls).setUpClass()
         cls.setUpComponent()
 
+    # pylint: disable=W8106
     def setUp(self):
         # resolve an inheritance issue (common.TransactionCase does not call
         # super)

--- a/payment_gateway_paypal/tests/paypal_mock.py
+++ b/payment_gateway_paypal/tests/paypal_mock.py
@@ -27,6 +27,7 @@ class PaypalPaymentSuccess(Mock):
     def __getitem__(self, key):
         return self.transaction[key]
 
+    # pylint: disable=W8106
     def create(self):
         self.transaction = copy.deepcopy(self.data)
         self.transaction.update({


### PR DESCRIPTION
**ADD**
The `current_transaction_id` must be a stored field to use it with the automatic workflow module (only stored field are usable).
Because we have to check the current transaction (only if transaction is a success) to validate the target.
(So we have to launch manually the recompute during transaction creation)

**IMP**
As the `res_id` and `res_model` are used into a search, it's better to index them.

**FIX**
In case of the invoice is not automatically validated, the self.number is `False`. Then the transaction name is also `False` and it fail to generate the transaction description.