### PR TITLE
[10.0][IMP] Make service methods private (as shouldn't be exposed/public)

### DIFF
--- a/payment_gateway/models/transaction_mixin.py
+++ b/payment_gateway/models/transaction_mixin.py
@@ -39,11 +39,10 @@ class TransactionMixin(models.AbstractModel):
 
     @api.multi
     def capture_transaction(self):
-        for record in self:
-            for transaction in record.transaction_ids:
-                if transaction.state == 'to_capture':
-                    amount = record._get_transaction_to_capture_amount()
-                    transaction.capture(amount)
+        transactions = self.mapped("transaction_ids").filtered(
+            lambda r: r.state == 'to_capture')
+        for transaction in transactions:
+            transaction.capture()
 
     @api.multi
     @api.depends('transaction_ids')

--- a/payment_gateway/services/payment_service.py
+++ b/payment_gateway/services/payment_service.py
@@ -54,7 +54,7 @@ class PaymentService(AbstractComponent):
         _logger.error("BadRequest %s", v.errors)
         raise UserError(_('Invalid Form'))
 
-    def dispatch(self, method_name, params):
+    def _dispatch(self, method_name, params):
         if method_name not in self._webhook_method:
             raise UserError(_('Method not allowed for service %s'), self._name)
 
@@ -91,15 +91,15 @@ class PaymentService(AbstractComponent):
     def _parse_creation_result(self, transaction, **kwargs):
         raise NotImplemented
 
-    def generate(self, **kwargs):
+    def _generate(self, **kwargs):
         """Generate the transaction in the provider backend
         and update the odoo gateway.transaction"""
         transaction = self._create_transaction(**kwargs)
         vals = self._parse_creation_result(transaction, **kwargs)
         return self.collection.write(vals)
 
-    def get_state(self):
+    def _get_state(self):
         raise NotImplemented
 
-    def capture(self, amount):
+    def _capture(self):
         raise NotImplemented

--- a/payment_gateway_adyen/services/payment_service.py
+++ b/payment_gateway_adyen/services/payment_service.py
@@ -120,8 +120,8 @@ class PaymentService(Component):
             _logger.info('Adyen Error %s' % e)
             self._raise_error_message('undef')
 
-    def process_return(self, browser_info=None, md=None, pares=None,
-                       shopper_ip=None, **params):
+    def _process_return(self, browser_info=None, md=None, pares=None,
+                        shopper_ip=None, **params):
         result = self._http_adyen_request('authorise3d', {
             'md': md,
             'paResponse': pares,
@@ -268,7 +268,7 @@ class PaymentService(Component):
                 }
             }
 
-    def capture(self):
+    def _capture(self):
         if self.collection.external_id.isdigit():
             payload = self._prepare_capture_payload()
             charge = self._get_adyen_client().capture(request=payload)

--- a/payment_gateway_adyen/tests/test_payment.py
+++ b/payment_gateway_adyen/tests/test_payment.py
@@ -212,12 +212,12 @@ class AdyenCase(AdyenCommonCase, AdyenScenario):
         }
         if success:
             with transaction._get_provider('adyen') as provider:
-                provider.process_return(**params)
+                provider._process_return(**params)
             self._check_captured(transaction)
         else:
             with self.assertRaises(UserError):
                 with transaction._get_provider('adyen') as provider:
-                    provider.process_return(**params)
+                    provider._process_return(**params)
             self.assertIn(transaction.state, ['pending', 'failed'])
 
     def _test_card(self, card, **kwargs):

--- a/payment_gateway_paypal/services/payment_service.py
+++ b/payment_gateway_paypal/services/payment_service.py
@@ -83,7 +83,7 @@ class PaymentService(Component):
             'state': 'pending',
         }
 
-    def process_return(self, **params):
+    def _process_return(self, **params):
         # For now we always capture immediatly the paypal transaction
         transaction = self.env['gateway.transaction'].search([
             ('external_id', '=', params['paymentId']),
@@ -97,7 +97,7 @@ class PaymentService(Component):
                 _('The transaction %s do not exist in Odoo')
                 % params['paymentId'])
 
-    def capture(self):
+    def _capture(self):
         transaction = self.collection
         paypal, experience_profile = self._get_connection()
         payment = paypalrestsdk.Payment.find(

--- a/payment_gateway_paypal/tests/test_payment.py
+++ b/payment_gateway_paypal/tests/test_payment.py
@@ -136,4 +136,4 @@ class PaypalCase(PaypalCommonCase, PaypalScenario):
     def _simulate_return(self, transaction_id):
         with self.env['gateway.transaction']._get_provider('paypal')\
                 as provider:
-            return provider.process_return(paymentId=transaction_id)
+            return provider._process_return(paymentId=transaction_id)

--- a/payment_gateway_stripe/services/payment_service.py
+++ b/payment_gateway_stripe/services/payment_service.py
@@ -38,7 +38,7 @@ class PaymentService(Component):
     _allowed_capture_method = ['immediately']
     _webhook_method = ['process_event']
 
-    def process_return(self, **params):
+    def _process_return(self, **params):
         transaction = self.env['gateway.transaction'].search([
             ('external_id', '=', params['source']),
             ('payment_mode_id.provider', '=', 'stripe'),
@@ -195,7 +195,7 @@ class PaymentService(Component):
 
     # code for getting the state of the current transaction
 
-    def get_state(self):
+    def _get_state(self):
         source = stripe.Source.retrieve(
             self.collection.external_id, api_key=self._api_key)
         return MAP_SOURCE_STATE[source['status']]
@@ -222,7 +222,7 @@ class PaymentService(Component):
             'api_key': self._api_key,
             }
 
-    def capture(self):
+    def _capture(self):
         if self.collection.external_id.startswith('src_'):
             # Transaction is a source convert it to a charge
             payload = self._prepare_capture_payload()

--- a/payment_gateway_stripe/tests/test_payment.py
+++ b/payment_gateway_stripe/tests/test_payment.py
@@ -136,7 +136,7 @@ class StripeCase(StripeCommonCase, StripeScenario):
 
     def _simulate_return(self, transaction):
         with transaction._get_provider('stripe') as provider:
-            provider.process_return(source=transaction.external_id)
+            provider._process_return(source=transaction.external_id)
 
     def _test_3d(self, card, success=True, mode='return'):
         transaction, source = self._create_transaction(card)


### PR DESCRIPTION
Some methods don't have leading `_` (so considerate as public).
It could be a security issue in some case.

Also, fix some bugs (some functions was called without correct parameters)